### PR TITLE
changed moveit dependence from 'moveit' to 'moveit_full'

### DIFF
--- a/moveit_utils/package.xml
+++ b/moveit_utils/package.xml
@@ -13,7 +13,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>jaco_msgs</build_depend>
-  <build_depend>moveit</build_depend>
+  <build_depend>moveit_full</build_depend>
   <run_depend>message_runtime</run_depend>
 
   <export>


### PR DESCRIPTION
otherwise running rosdep install ... results in an error as there is no ros package called just "moveit"
