### PR TITLE
Change default planner

### DIFF
--- a/mico_moveit_fullsegbot_config/config/ompl_planning.yaml
+++ b/mico_moveit_fullsegbot_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 arm:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault


### PR DESCRIPTION
This changes the default OMPL planner from SBLkConfigDefault  to RRTConnectkConfigDefault, which is _much_ faster in computing plans, and _possibly_ produces better trajectories (though I suspect we'll actually need to switch kinematic plugins for that).

Note that we can test out different planners by running  
`roslaunch mico_full_segbot_config demo.launch`  
and selecting a planner configuration from the drop down menu. We can then query goals, plan trajectories, and compare how quickly they are computed and if they produce extraneous movements.
